### PR TITLE
Code quality fix - Parentheses should be removed from a single lambda input parameter when its type is inferred.

### DIFF
--- a/petitparser-core/src/main/java/org/petitparser/parser/primitive/CharacterPredicate.java
+++ b/petitparser-core/src/main/java/org/petitparser/parser/primitive/CharacterPredicate.java
@@ -24,7 +24,7 @@ public interface CharacterPredicate {
    */
   static CharacterPredicate anyOf(String string) {
     List<CharacterRange> ranges = string.chars()
-        .mapToObj((value) -> new CharacterRange((char) value, (char) value))
+        .mapToObj(value -> new CharacterRange((char) value, (char) value))
         .collect(Collectors.toList());
     return CharacterRange.toCharacterPredicate(ranges);
   }
@@ -41,7 +41,7 @@ public interface CharacterPredicate {
    */
   static CharacterPredicate noneOf(String string) {
     List<CharacterRange> ranges = string.chars()
-        .mapToObj((value) -> new CharacterRange((char) value, (char) value))
+        .mapToObj(value -> new CharacterRange((char) value, (char) value))
         .collect(Collectors.toList());
     return CharacterRange.toCharacterPredicate(ranges).not();
   }

--- a/petitparser-core/src/main/java/org/petitparser/utils/Functions.java
+++ b/petitparser-core/src/main/java/org/petitparser/utils/Functions.java
@@ -15,14 +15,14 @@ public class Functions {
    * Returns a function that returns the first value of a list.
    */
   public static <T> Function<List<T>, T> firstOfList() {
-    return (list) -> list.get(0);
+    return list -> list.get(0);
   }
 
   /**
    * Returns a function that returns the last value of a list.
    */
   public static <T> Function<List<T>, T> lastOfList() {
-    return (list) -> list.get(list.size() - 1);
+    return list -> list.get(list.size() - 1);
   }
 
   /**
@@ -30,7 +30,7 @@ public class Functions {
    * the end of the list.
    */
   public static <T> Function<List<T>, T> nthOfList(int index) {
-    return (list) -> list.get(index < 0 ? list.size() + index : index);
+    return list -> list.get(index < 0 ? list.size() + index : index);
   }
 
   /**
@@ -38,7 +38,7 @@ public class Functions {
    * from the end of the list.
    */
   public static <T> Function<List<T>, List<T>> permutationOfList(int... indexes) {
-    return (list) -> {
+    return list -> {
       List<T> result = new ArrayList<>(indexes.length);
       for (int index : indexes) {
         result.add(list.get(index < 0 ? list.size() + index : index));
@@ -52,7 +52,7 @@ public class Functions {
    * Parser#separatedBy(Parser)}.
    */
   public static <T> Function<List<T>, List<T>> withoutSeparators() {
-    return (list) -> {
+    return list -> {
       List<T> result = new ArrayList<>();
       for (int i = 0; i < list.size(); i += 2) {
         result.add(list.get(i));
@@ -65,6 +65,6 @@ public class Functions {
    * Returns a function that returns a constant value.
    */
   public static <T> Function<Object, T> constant(T output) {
-    return (input) -> output;
+    return input -> output;
   }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1611 - Performance - Parentheses should be removed from a single lambda input parameter when its type is inferred.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1611

Please let me know if you have any questions.

Faisal Hameed