### PR TITLE
General code quality fix-1

### DIFF
--- a/petitparser-core/src/main/java/org/petitparser/parser/primitive/CharacterPredicate.java
+++ b/petitparser-core/src/main/java/org/petitparser/parser/primitive/CharacterPredicate.java
@@ -91,6 +91,10 @@ public interface CharacterPredicate {
   }
 
   class PatternParser {
+    
+    private PatternParser() {
+        
+    }
     static final Parser PATTERN_SIMPLE = CharacterParser.any()
         .map((Character value) -> new CharacterRange(value, value));
     static final Parser PATTERN_RANGE = CharacterParser.any()

--- a/petitparser-core/src/main/java/org/petitparser/utils/Functions.java
+++ b/petitparser-core/src/main/java/org/petitparser/utils/Functions.java
@@ -11,6 +11,10 @@ import java.util.function.Function;
  */
 public class Functions {
 
+  private Functions() {
+      
+  }  
+    
   /**
    * Returns a function that returns the first value of a list.
    */

--- a/petitparser-core/src/main/java/org/petitparser/utils/Profiler.java
+++ b/petitparser-core/src/main/java/org/petitparser/utils/Profiler.java
@@ -12,6 +12,10 @@ import java.util.function.Consumer;
  */
 public class Profiler {
 
+  private Profiler() {
+      
+  }
+    
   /**
    * Returns a parser that calls the provided consumer with a {@link Profile} of every parser.
    */

--- a/petitparser-xml/src/main/java/org/petitparser/grammar/xml/ast/XmlNode.java
+++ b/petitparser-xml/src/main/java/org/petitparser/grammar/xml/ast/XmlNode.java
@@ -79,7 +79,7 @@ public abstract class XmlNode implements Iterable<XmlNode> {
    */
   public final XmlNode getFirstChild() {
     List<XmlNode> children = getChildren();
-    return children.size() > 0 ? children.get(0) : null;
+    return !children.isEmpty() ? children.get(0) : null;
   }
 
   /**
@@ -87,7 +87,7 @@ public abstract class XmlNode implements Iterable<XmlNode> {
    */
   public final XmlNode getLastChild() {
     List<XmlNode> children = getChildren();
-    return children.size() > 0 ? children.get(children.size() - 1) : null;
+    return !children.isEmpty() ? children.get(children.size() - 1) : null;
   }
 
   /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1155 - Collection.isEmpty() should be used to test for emptiness. 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1155
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.

Faisal Hameed