### PR TITLE
Code quality fix - Null pointers should not be dereferenced.

### DIFF
--- a/petitparser-xml/src/main/java/org/petitparser/grammar/xml/ast/XmlElement.java
+++ b/petitparser-xml/src/main/java/org/petitparser/grammar/xml/ast/XmlElement.java
@@ -73,6 +73,9 @@ public class XmlElement extends XmlParent {
     if (this == obj) {
       return true;
     }
+    if (obj == null) {
+      return false;
+    }
     if (!super.equals(obj) || getClass() != obj.getClass()) {
       return false;
     }

--- a/petitparser-xml/src/main/java/org/petitparser/grammar/xml/ast/XmlProcessing.java
+++ b/petitparser-xml/src/main/java/org/petitparser/grammar/xml/ast/XmlProcessing.java
@@ -36,6 +36,9 @@ public class XmlProcessing extends XmlData {
     if (this == obj) {
       return true;
     }
+    if (obj == null) {
+      return false;
+    }
     if (!super.equals(obj) || getClass() != obj.getClass()) {
       return false;
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2259- Null pointers should not be dereferenced.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2259

Please let me know if you have any questions.

Faisal Hameed