### PR TITLE
Code quality fix - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.

### DIFF
--- a/petitparser-xml/src/main/java/org/petitparser/grammar/xml/ast/XmlAttribute.java
+++ b/petitparser-xml/src/main/java/org/petitparser/grammar/xml/ast/XmlAttribute.java
@@ -27,7 +27,7 @@ public class XmlAttribute extends XmlNode {
   }
 
   @Override
-  public void writeTo(StringBuffer buffer) {
+  public void writeTo(StringBuilder buffer) {
     name.writeTo(buffer);
     buffer.append(XmlGrammar.EQUALS);
     buffer.append(XmlGrammar.DOUBLE_QUOTE);

--- a/petitparser-xml/src/main/java/org/petitparser/grammar/xml/ast/XmlElement.java
+++ b/petitparser-xml/src/main/java/org/petitparser/grammar/xml/ast/XmlElement.java
@@ -49,7 +49,7 @@ public class XmlElement extends XmlParent {
   }
 
   @Override
-  public void writeTo(StringBuffer buffer) {
+  public void writeTo(StringBuilder buffer) {
     buffer.append(XmlGrammar.OPEN_ELEMENT);
     getName().writeTo(buffer);
     for (XmlAttribute attribute : getAttributes()) {

--- a/petitparser-xml/src/main/java/org/petitparser/grammar/xml/ast/XmlName.java
+++ b/petitparser-xml/src/main/java/org/petitparser/grammar/xml/ast/XmlName.java
@@ -39,12 +39,12 @@ public class XmlName implements Cloneable {
   }
 
   public String toXmlString() {
-    StringBuffer buffer = new StringBuffer();
+    StringBuilder buffer = new StringBuilder();
     writeTo(buffer);
     return buffer.toString();
   }
 
-  public void writeTo(StringBuffer buffer) {
+  public void writeTo(StringBuilder buffer) {
     if (prefix != null) {
       buffer.append(prefix).append(':');
     }

--- a/petitparser-xml/src/main/java/org/petitparser/grammar/xml/ast/XmlNode.java
+++ b/petitparser-xml/src/main/java/org/petitparser/grammar/xml/ast/XmlNode.java
@@ -136,7 +136,7 @@ public abstract class XmlNode implements Iterable<XmlNode> {
    * Answer an XML string of the receiver.
    */
   public String toXmlString() {
-    StringBuffer buffer = new StringBuffer();
+    StringBuilder buffer = new StringBuilder();
     writeTo(buffer);
     return buffer.toString();
   }
@@ -144,5 +144,5 @@ public abstract class XmlNode implements Iterable<XmlNode> {
   /**
    * Writes the XML string of the receiver to a {@code buffer}.
    */
-  public abstract void writeTo(StringBuffer buffer);
+  public abstract void writeTo(StringBuilder buffer);
 }

--- a/petitparser-xml/src/main/java/org/petitparser/grammar/xml/ast/XmlParent.java
+++ b/petitparser-xml/src/main/java/org/petitparser/grammar/xml/ast/XmlParent.java
@@ -24,7 +24,7 @@ public abstract class XmlParent extends XmlNode {
   }
 
   @Override
-  public void writeTo(StringBuffer buffer) {
+  public void writeTo(StringBuilder buffer) {
     for (XmlNode node : getChildren()) {
       node.writeTo(buffer);
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149

Please let me know if you have any questions.

Faisal Hameed