### PR TITLE
Code quality fix - The members of an interface declaration or class should appear in a pre-defined order.

### DIFF
--- a/petitparser-core/src/main/java/org/petitparser/context/Token.java
+++ b/petitparser-core/src/main/java/org/petitparser/context/Token.java
@@ -37,6 +37,11 @@ public class Token {
   private final Object value;
 
   /**
+   * Returns a parser for that detects newlines platform independently.
+   */
+  public static final Parser NEWLINE_PARSER = of('\n').or(of('\r').seq(of('\n').optional()));
+
+  /**
    * Constructs a token from the parsed value, the input buffer, and the start and stop position in
    * the input buffer.
    */
@@ -138,11 +143,6 @@ public class Token {
   public int hashCode() {
     return Objects.hash(value, buffer, start, stop);
   }
-
-  /**
-   * Returns a parser for that detects newlines platform independently.
-   */
-  public static final Parser NEWLINE_PARSER = of('\n').or(of('\r').seq(of('\n').optional()));
 
   /**
    * Converts the {@code position} index in a {@code buffer} to a line and column tuple.

--- a/petitparser-core/src/main/java/org/petitparser/parser/combinators/SettableParser.java
+++ b/petitparser-core/src/main/java/org/petitparser/parser/combinators/SettableParser.java
@@ -8,6 +8,10 @@ import org.petitparser.parser.primitive.FailureParser;
  */
 public class SettableParser extends DelegateParser {
 
+  public SettableParser(Parser delegate) {
+    super(delegate);
+  }
+
   /**
    * Constructs a {@link SettableParser} that currently refers to an {@link FailureParser}.
    */
@@ -28,10 +32,6 @@ public class SettableParser extends DelegateParser {
    */
   public static SettableParser with(Parser parser) {
     return new SettableParser(parser);
-  }
-
-  public SettableParser(Parser delegate) {
-    super(delegate);
   }
 
   /**

--- a/petitparser-core/src/main/java/org/petitparser/parser/primitive/CharacterParser.java
+++ b/petitparser-core/src/main/java/org/petitparser/parser/primitive/CharacterParser.java
@@ -11,6 +11,15 @@ import java.util.Objects;
  */
 public class CharacterParser extends Parser {
 
+
+  private final CharacterPredicate matcher;
+  private final String message;
+
+  private CharacterParser(CharacterPredicate matcher, String message) {
+    this.matcher = Objects.requireNonNull(matcher, "Undefined matcher");
+    this.message = Objects.requireNonNull(message, "Undefined message");
+  }
+
   /**
    * Returns a parser that accepts a specific {@link CharacterPredicate}.
    */
@@ -162,14 +171,6 @@ public class CharacterParser extends Parser {
 
   public static Parser word(String message) {
     return of(Character::isLetterOrDigit, message);
-  }
-
-  private final CharacterPredicate matcher;
-  private final String message;
-
-  private CharacterParser(CharacterPredicate matcher, String message) {
-    this.matcher = Objects.requireNonNull(matcher, "Undefined matcher");
-    this.message = Objects.requireNonNull(message, "Undefined message");
   }
 
   @Override

--- a/petitparser-core/src/main/java/org/petitparser/parser/primitive/CharacterRange.java
+++ b/petitparser-core/src/main/java/org/petitparser/parser/primitive/CharacterRange.java
@@ -15,6 +15,15 @@ class CharacterRange {
           .comparing((CharacterRange range) -> range.start)
           .thenComparing((CharacterRange range) -> range.stop);
 
+
+  private final char start;
+  private final char stop;
+
+  CharacterRange(char start, char stop) {
+    this.start = start;
+    this.stop = stop;
+  }
+
   static CharacterPredicate toCharacterPredicate(List<CharacterRange> ranges) {
 
     // 1. sort the ranges
@@ -56,11 +65,4 @@ class CharacterRange {
     }
   }
 
-  private final char start;
-  private final char stop;
-
-  CharacterRange(char start, char stop) {
-    this.start = start;
-    this.stop = stop;
-  }
 }

--- a/petitparser-core/src/main/java/org/petitparser/parser/primitive/FailureParser.java
+++ b/petitparser-core/src/main/java/org/petitparser/parser/primitive/FailureParser.java
@@ -11,17 +11,18 @@ import java.util.Objects;
  */
 public class FailureParser extends Parser {
 
-  /**
-   * Construct a {@link FailureParser} that fails with the supplied {@code message}.
-   */
-  public static Parser withMessage(String message) {
-    return new FailureParser(message);
-  }
 
   private final String message;
 
   private FailureParser(String message) {
     this.message = Objects.requireNonNull(message, "Undefined message");
+  }
+
+  /**
+   * Construct a {@link FailureParser} that fails with the supplied {@code message}.
+   */
+  public static Parser withMessage(String message) {
+    return new FailureParser(message);
   }
 
   @Override

--- a/petitparser-core/src/main/java/org/petitparser/parser/primitive/StringParser.java
+++ b/petitparser-core/src/main/java/org/petitparser/parser/primitive/StringParser.java
@@ -12,6 +12,17 @@ import java.util.function.Predicate;
  */
 public class StringParser extends Parser {
 
+
+  private final int size;
+  private final Predicate<String> predicate;
+  private final String message;
+
+  private StringParser(int size, Predicate<String> predicate, String message) {
+    this.size = size;
+    this.predicate = Objects.requireNonNull(predicate, "Undefined predicate");
+    this.message = Objects.requireNonNull(message, "Undefined message");
+  }
+
   /**
    * Construct a parser that accepts the provides {@link String} {@code value}.
    */
@@ -40,16 +51,6 @@ public class StringParser extends Parser {
    */
   public static Parser ofIgnoringCase(String value, String message) {
     return new StringParser(value.length(), value::equalsIgnoreCase, message);
-  }
-
-  private final int size;
-  private final Predicate<String> predicate;
-  private final String message;
-
-  private StringParser(int size, Predicate<String> predicate, String message) {
-    this.size = size;
-    this.predicate = Objects.requireNonNull(predicate, "Undefined predicate");
-    this.message = Objects.requireNonNull(message, "Undefined message");
   }
 
   @Override

--- a/petitparser-core/src/main/java/org/petitparser/utils/Mirror.java
+++ b/petitparser-core/src/main/java/org/petitparser/utils/Mirror.java
@@ -22,17 +22,18 @@ import java.util.stream.StreamSupport;
  */
 public class Mirror implements Iterable<Parser> {
 
-  /**
-   * Constructs a mirror of the provided {@code parser}.
-   */
-  public static Mirror of(Parser parser) {
-    return new Mirror(parser);
-  }
 
   private final Parser parser;
 
   private Mirror(Parser parser) {
     this.parser = Objects.requireNonNull(parser, "Undefined parser");
+  }
+
+  /**
+   * Constructs a mirror of the provided {@code parser}.
+   */
+  public static Mirror of(Parser parser) {
+    return new Mirror(parser);
   }
 
   @Override

--- a/petitparser-core/src/main/java/org/petitparser/utils/Tracer.java
+++ b/petitparser-core/src/main/java/org/petitparser/utils/Tracer.java
@@ -65,18 +65,19 @@ public class Tracer {
      */
     public final Context context;
 
-    /**
-     * The current invocation level.
-     */
-    public int getLevel() {
-      return parent != null ? 1 + parent.getLevel() : 0;
-    }
 
     private TraceEvent(TraceEventType type, TraceEvent parent, Parser parser, Context context) {
       this.type = type;
       this.parent = parent;
       this.parser = parser;
       this.context = context;
+    }
+
+    /**
+     * The current invocation level.
+     */
+    public int getLevel() {
+      return parent != null ? 1 + parent.getLevel() : 0;
     }
 
     @Override

--- a/petitparser-json/src/main/java/org/petitparser/grammar/json/JsonGrammar.java
+++ b/petitparser-json/src/main/java/org/petitparser/grammar/json/JsonGrammar.java
@@ -19,6 +19,10 @@ import static org.petitparser.parser.primitive.StringParser.of;
  */
 public class JsonGrammar extends CompositeParser {
 
+
+  protected static final Map<Character, Character> ESCAPE_TABLE = createEscapeTable();
+  protected static final Function<Character, Character> ESCAPE_TABLE_FUNCTION = ESCAPE_TABLE::get;
+
   protected static Map<Character, Character> createEscapeTable() {
     Map<Character, Character> table = new HashMap<>();
     table.put('\\', '\\');
@@ -37,9 +41,6 @@ public class JsonGrammar extends CompositeParser {
     characters.forEach(builder::append);
     return builder.toString();
   }
-
-  protected static final Map<Character, Character> ESCAPE_TABLE = createEscapeTable();
-  protected static final Function<Character, Character> ESCAPE_TABLE_FUNCTION = ESCAPE_TABLE::get;
 
   @Override
   protected void initialize() {

--- a/petitparser-xml/src/main/java/org/petitparser/grammar/xml/XmlCharacterParser.java
+++ b/petitparser-xml/src/main/java/org/petitparser/grammar/xml/XmlCharacterParser.java
@@ -300,17 +300,6 @@ public class XmlCharacterParser extends Parser {
       .seq(of(';'))
       .pick(1);
 
-  // Encode a string to be serialized as an XML text node.
-  public static String encodeXmlText(String input) {
-    // only & and < need to be encoded in text
-    return input.replace("&", "&amp;").replace("<", "&lt;");
-  }
-
-  // Encode a string to be serialized as an XML attribute value.
-  public static String encodeXmlAttributeValue(String input) {
-    // only " needs to be encoded in attribute value
-    return input.replaceAll("\"", "&quot;");
-  }
 
   private final char stopper;
   private final int minLength;
@@ -322,6 +311,18 @@ public class XmlCharacterParser extends Parser {
   XmlCharacterParser(char stopper, int minLength) {
     this.stopper = stopper;
     this.minLength = minLength;
+  }
+
+  // Encode a string to be serialized as an XML text node.
+  public static String encodeXmlText(String input) {
+    // only & and < need to be encoded in text
+    return input.replace("&", "&amp;").replace("<", "&lt;");
+  }
+
+  // Encode a string to be serialized as an XML attribute value.
+  public static String encodeXmlAttributeValue(String input) {
+    // only " needs to be encoded in attribute value
+    return input.replaceAll("\"", "&quot;");
   }
 
   @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213

Please let me know if you have any questions.

Faisal Hameed