### PR TITLE
Return more usefull failure message for Token.NEWLINE_PARSER

### DIFF
--- a/petitparser-core/src/main/java/org/petitparser/context/Token.java
+++ b/petitparser-core/src/main/java/org/petitparser/context/Token.java
@@ -143,7 +143,7 @@ public class Token {
    * Returns a parser for that detects newlines platform independently.
    */
   public static final Parser NEWLINE_PARSER =
-      of('\n').or(of('\r').seq(of('\n').optional()));
+      of('\n').or(of('\r', "'NEWLINE' expected").seq(of('\n').optional()));
 
   /**
    * Converts the {@code position} index in a {@code buffer} to a line and


### PR DESCRIPTION
Token.NEWLINE_PARSER returns a newline or carriage return as failure message. This is not very useful because it moves the cursor to the beginning of the line. In my project I'm using a logger class which writes timestamps and class names at the beginning of the line. Because of the carriage return this gets overwritten. Example:
```
Validator version: 2.1.6-SNAPSHOT
' expected40 ERROR massbank.Validator - '
16:49:00.343 ERROR massbank.Validator -   99.00676994602972 57.0 57.0
16:49:00.347 ERROR massbank.Validator -                            ^
16:49:00.347 ERROR massbank.Validator - Error in 'records/recdata/BU000001.txt'.
```
More readable and understandable would be:
```
Validator version: 2.1.6-SNAPSHOT
17:46:28.226 ERROR massbank.Validator - 'NEWLINE' expected
17:46:28.230 ERROR massbank.Validator -   99.00676994602972 57.0 57.0
17:46:28.236 ERROR massbank.Validator -                            ^
17:46:28.236 ERROR massbank.Validator - Error in 'records/recdata/BU000001.txt'.
```