### PR TITLE
Adding fixed versions and moving from Adopt to Zulu

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '11', '14' ]
+        java: [ '11', '11.0.3', '14', '14.0.1' ]
     name: Java ${{ matrix.Java }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: ${{ matrix.Java }}
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v2
       with:
-        distribution: 'temurin'
+        distribution: 'zulu'
         java-version: ${{ matrix.Java }}
     - name: Build with Maven
       run: mvn -B package --file pom.xml


### PR DESCRIPTION
If your GitHub Action actions/setup-java workflow has fixed JDK versions, e.g., 11.0.3, in addition to the latest version, e.g., 11, you'll know when the first goes green and the second goes red that there is a problem specifically with the latest version and not with your application code.

Adopt is no more, only Temurin and Zulu are available, only Zulu supports multiple JDK versions, therefore this pull request provides fixed versions together with Zulu.