### PR TITLE
Add unit tests for ExpressionBuilder

### DIFF
--- a/petitparser-core/src/test/java/org/petitparser/tools/ExpressionBuilderTest.java
+++ b/petitparser-core/src/test/java/org/petitparser/tools/ExpressionBuilderTest.java
@@ -2,12 +2,15 @@ package org.petitparser.tools;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.petitparser.context.Result;
 import org.petitparser.parser.Parser;
 
 import java.util.List;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.petitparser.parser.primitive.CharacterParser.digit;
 import static org.petitparser.parser.primitive.CharacterParser.of;
 import static org.petitparser.parser.primitive.StringParser.of;
@@ -312,5 +315,13 @@ public class ExpressionBuilderTest {
     assertEvaluation("-1", -1);
     assertEvaluation("--1", 1);
     assertEvaluation("---1", -1);
+  }
+
+  @Test
+  public void testBuildWithoutGroupsFails() {
+    Parser parser = new ExpressionBuilder().build();
+    assertNotNull(parser);
+    Result result = parser.parse("");
+    assertTrue(result.isFailure());
   }
 }


### PR DESCRIPTION
Additive unit tests for `ExpressionBuilder` — edge cases and current behavior pinned with explicit assertions. No existing test or production code changed.

Verified green under Java 11 (`mvn -pl petitparser-core test -Dtest=ExpressionBuilderTest` → Tests run: 30, Failures: 0, Errors: 0).
